### PR TITLE
babel exclude changed to "node_modules/**"

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,12 +14,12 @@ const globals = {
 }
 
 const babelOptions = {
-  exclude: /node_modules/,
+  exclude: 'node_modules/**',
   runtimeHelpers: true,
 }
 
 const commonjsOptions = {
-  include: /node_modules/,
+  include: 'node_modules/**',
 }
 
 export default [


### PR DESCRIPTION
`babel` `exclude` and `commonjs` `include` parameters changed from `/node_modules/` to 'node_modules/**' to not affect  parent "node_modules" directory